### PR TITLE
[sailfishos-chum-repo-config.spec] Add missed `Vendor:  chum` …

### DIFF
--- a/rpm/sailfishos-chum-repo-config.spec
+++ b/rpm/sailfishos-chum-repo-config.spec
@@ -8,6 +8,7 @@ Release:        1
 Group:          Software Management/Package Manager
 BuildArch:      noarch
 URL:            https://github.com/sailfishos-chum/%{name}
+Vendor:         chum
 # The "Source0:" line below requires that the value of %%{name} is also the
 # project name at GitHub and the value of %%{version} is also the name of a
 # correspondingly set git-tag.


### PR DESCRIPTION
… in order to have a static vendor set across all distribution channels (GitHub Releases page, OpenRepos and SailfishOS:Chum community repository at SailfishOS-OBS), to allow for updates despite switching distribution channels (see [SDB: Vendor change update Overview](https://en.opensuse.org/SDB:Vendor_change_update#Overview)).