### PR TITLE
[rpm/sailfishos-chum-repo-config.spec] Move *all* comments to seperate lines, …

### DIFF
--- a/rpm/sailfishos-chum-repo-config.spec
+++ b/rpm/sailfishos-chum-repo-config.spec
@@ -188,7 +188,8 @@ ssu ur
 exit 0
 
 %postun
-if [ "$1" = 0 ]  # Removal
+if [ "$1" = 0 ]
+# Removal
 then
   ssu rr sailfishos-chum
   rm -f /var/cache/ssu/features.ini
@@ -197,7 +198,8 @@ fi
 exit 0
 
 %postun testing
-if [ "$1" = 0 ]  # Removal
+if [ "$1" = 0 ]
+# Removal
 then
   ssu rr sailfishos-chum-testing
   rm -f /var/cache/ssu/features.ini


### PR DESCRIPTION
… even though this is not necessary in sriptlets.  But having inline comments in the scriptlets invites to use this scheme elsewhere in the spec file, which might cause havoc.